### PR TITLE
added ncores argument; refactored code; converted cat to message

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,5 @@
 ^README.md
 ^LICENCE\.md$
 ^LICENSE\.md$
+^doc$
+^Meta$

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 ## Folder to put local/personal content
 local/
 
+/doc/
+/Meta/

--- a/R/add_time.R
+++ b/R/add_time.R
@@ -147,7 +147,8 @@ add_time=function(dt, eventObj, clinInt, clinExt, seed){
   keep = eventObj@keep
   if (is.null(keep)) {
     keep = cov_name
-    message(cat("All original covariates (if any):", keep, "are used for time-to-failure."))
+    msg <- paste("All original covariates (if any):", paste(keep, collapse = " "), "are used for time-to-failure.")
+    message(msg)
   } else if (sum(grepl("none", keep)) > 0){
     keep = NULL
     message("No original covariates are used for time-to-failure.")

--- a/R/run_mcmc.R
+++ b/R/run_mcmc.R
@@ -82,6 +82,7 @@ run_mcmc <- function(dt, priorObj, n.chains, n.adapt, n.burn, n.iter, seed, path
 #' @param n.iter number of iterations to monitor
 #' @param seed the seed of random number generator. Default is the first element of .Random.seed
 #' @param path file name for saving the output including folder path
+#' @param n.cores number of processes to parallelize over (default = 2)
 #' @return a \code{data.frame} containing summary statistics of the posterior distribution for each simulation
 #'
 #' @examples
@@ -90,63 +91,82 @@ run_mcmc <- function(dt, priorObj, n.chains, n.adapt, n.burn, n.iter, seed, path
 #'
 #' @export
 #' @keywords simulator
-run_mcmc_p <- function(dt, priorObj, n.chains, n.adapt, n.burn, n.iter, seed, path){
-  
+run_mcmc_p <- function(dt, priorObj, n.chains, n.adapt, n.burn, n.iter, seed, path, n.cores = 2){
+
   if (missing(dt)) stop("Please provide a list of simulated time (dt).")
   if (missing(priorObj)) stop("Please provide .priorObj (priorObj).")
   n_mcmc <- valid_mcmc(n.chains, n.adapt, n.burn, n.iter)
-  
-  if (missing(seed)){
+
+  if (missing(seed)) {
     message("Running MCMC... Set seed to ", .Random.seed[1])
-    seed = .Random.seed[1]
-  } else set.seed(seed)
+    seed <- .Random.seed[1]
+  } else {
+    set.seed(seed)
+  }
   seed_list <- seq(seed, seed + length(dt), by = 1)
-  
-  flog.debug(cat("seed_list:", seed_list, "number of dataset", length(dt), "\n"))
-  
-  # nCluster <- parallel::detectCores()
-  nCluster <- 2 # switch to 2 cluster per CRAN's requirement
-  message(nCluster, " clusters are being used")
-  cl <- parallel::makeCluster(nCluster)
+
+  flog.debug(
+    cat("seed_list:", seed_list, "number of dataset", length(dt), "\n")
+  )
+
+  message(n.cores, " clusters are being used")
+  cl <- parallel::makeCluster(n.cores)
   doParallel::registerDoParallel(cl)
-  
+
   # set i to NULL to avoid CRAN warnings
   i <- NULL
-  
-  res_list <- foreach(i = 1:length(dt), .combine='c', .multicombine=TRUE,.packages = c("psborrow"),
-                      # .export = c("format_number", "format_date_time", "add_direction_data"),
-                      # .packages = c("tidyverse", "data.table", "dplyr", "rjags"),
-                      .verbose=FALSE) %dopar% {
-                        
-                        seed_i = seed_list[i]
-                        
-                        message("------------------- Running MCMC: #", i, " of ", length(dt), " simulated dataset with seed = ", seed_i)
-                        
-                        add_mcmc(dt = dt[[i]], priorObj = priorObj,
-                                 n.chains = n.chains, n.adapt = n.adapt,
-                                 n.burn = n.burn, n.iter = n.iter, seed = seed_i)
-                      } #loop foreach
-  
+
+  res_list <- foreach(
+    i = seq_len(length(dt)),
+    .combine = "c",
+    .multicombine = TRUE,
+    .packages = c("psborrow"),
+    # .export = c("format_number", "format_date_time", "add_direction_data"),
+    # .packages = c("tidyverse", "data.table", "dplyr", "rjags"),
+    .verbose = FALSE
+  ) %dopar% {
+
+    seed_i <- seed_list[i]
+
+    message(
+      "------------------- Running MCMC: #",
+      i, " of ", length(dt),
+      " simulated dataset with seed = ",
+      seed_i
+    )
+
+    add_mcmc(dt = dt[[i]], priorObj = priorObj,
+              n.chains = n.chains, n.adapt = n.adapt,
+              n.burn = n.burn, n.iter = n.iter, seed = seed_i)
+  }
+
   parallel::stopCluster(cl)
   sum_list <- lapply(res_list, function(i) {
-    cbind("HR" = i[['HR']], "driftHR" = i[['driftHR']],
-          "prior" = i[['prior']], "pred" = i[['pred']],
-          "reject" = i[['summary']]['reject'],
-          "mean_HR" = i[['summary']]['mean_HR'],
-          "sd_HR" = i[['summary']]['sd_HR'],
-          "mean_driftHR" = i[['summary']]['mean_driftHR'],
-          "sd_driftHR" = i[['summary']]['sd_driftHR'])})
+    cbind(
+      "HR" = i[["HR"]],
+      "driftHR" = i[["driftHR"]],
+      "prior" = i[["prior"]],
+      "pred" = i[["pred"]],
+      "reject" = i[["summary"]]["reject"],
+      "mean_HR" = i[["summary"]]["mean_HR"],
+      "sd_HR" = i[["summary"]]["sd_HR"],
+      "mean_driftHR" = i[["summary"]]["mean_driftHR"],
+      "sd_driftHR" = i[["summary"]]["sd_driftHR"]
+    )
+  })
   sum_dt <- as.data.frame(do.call(rbind, sum_list))
   rownames(sum_dt) <- NULL
-  sum_dt$HR = as.numeric(sum_dt$HR)
-  sum_dt$driftHR = as.numeric(sum_dt$driftHR)
-  sum_dt$reject = as.numeric(sum_dt$reject)
-  sum_dt$mean_HR = as.numeric(sum_dt$mean_HR)
-  sum_dt$sd_HR = as.numeric(sum_dt$sd_HR)
-  sum_dt$mean_driftHR = as.numeric(sum_dt$mean_driftHR)
-  sum_dt$sd_driftHR = as.numeric(sum_dt$sd_driftHR)
-  
-  if (missing(path)) message("Samples from the posterior distribution from MCMC are not saved.") else {
+  sum_dt$HR <- as.numeric(sum_dt$HR)
+  sum_dt$driftHR <- as.numeric(sum_dt$driftHR)
+  sum_dt$reject <- as.numeric(sum_dt$reject)
+  sum_dt$mean_HR <- as.numeric(sum_dt$mean_HR)
+  sum_dt$sd_HR <- as.numeric(sum_dt$sd_HR)
+  sum_dt$mean_driftHR <- as.numeric(sum_dt$mean_driftHR)
+  sum_dt$sd_driftHR <- as.numeric(sum_dt$sd_driftHR)
+
+  if (missing(path)) {
+    message("Samples from the posterior distribution from MCMC are not saved.")
+  } else {
     save(sum_dt, file = path)
     message("Results the posterior distribution from MCMC are saved as ", path)
   }

--- a/man/run_mcmc_p.Rd
+++ b/man/run_mcmc_p.Rd
@@ -4,7 +4,17 @@
 \alias{run_mcmc_p}
 \title{Run MCMC for multiple scenarios with provided data with parallel processing}
 \usage{
-run_mcmc_p(dt, priorObj, n.chains, n.adapt, n.burn, n.iter, seed, path)
+run_mcmc_p(
+  dt,
+  priorObj,
+  n.chains,
+  n.adapt,
+  n.burn,
+  n.iter,
+  seed,
+  path,
+  n.cores = 2
+)
 }
 \arguments{
 \item{dt}{a list of \code{matrix} containing simulated time-to-events information}
@@ -22,6 +32,8 @@ run_mcmc_p(dt, priorObj, n.chains, n.adapt, n.burn, n.iter, seed, path)
 \item{seed}{the seed of random number generator. Default is the first element of .Random.seed}
 
 \item{path}{file name for saving the output including folder path}
+
+\item{n.cores}{number of processes to parallelize over (default = 2)}
 }
 \value{
 a \code{data.frame} containing summary statistics of the posterior distribution for each simulation

--- a/tests/testthat/test-parallel.R
+++ b/tests/testthat/test-parallel.R
@@ -1,0 +1,91 @@
+
+
+library(dplyr)
+library(purrr)
+
+test_that("parallisation works as expected", {
+    suppressMessages({
+        ss <- set_n(
+            ssC = 80,
+            ssE = 90,
+            ssExt = 150
+        )
+
+        covset1 <- set_cov(
+            n_cat = 2,
+            n_cont = 1,
+            mu_int = c(0, 0.5, 0.5),
+            mu_ext = c(0.7, 0.5, 0.9),
+            var = c(1, 1.2, 1),
+            cov = c(0.5, 0.7, 0.9),
+            prob_int = c(0.45, 0.55),
+            prob_ext = c(0.65, 0.55)
+        )
+
+        sample_cov <- simu_cov(
+            ssObj = ss,
+            covObj = covset1,
+            HR = c(0.67),
+            driftHR = c(1),
+            nsim = 4,
+            seed = 47
+        )
+
+        evt <- set_event(
+            event = "weibull",
+            shape = 0.9,
+            lambdaC = 0.0135,
+            beta = 0.5
+        )
+
+        c_int <- set_clin(
+            gamma = c(2, 3, 16),
+            e_itv = c(5, 10),
+            CCOD = "fixed-first",
+            CCOD_t = 45,
+            etaC = c(0.02, 0.03),
+            etaE = c(0.2, 0.3),
+            d_itv = 2
+        )
+
+        c_ext <- set_clin(
+            gamma = 10,
+            CCOD = "event",
+            CCOD_t = 150,
+            etaC = 0.05
+        )
+
+        sample_time <- simu_time(
+            dt = sample_cov,
+            eventObj = evt,
+            clinInt = c_int,
+            clinExt = c_ext,
+            seed = 47
+        )
+
+        res <- run_mcmc(
+            dt = sample_time,
+            set_prior(pred = "all", prior = "gamma", r0 = 1,  alpha = c(0, 0)),
+            n.chains = 2,
+            n.adapt = 100,
+            n.burn = 100,
+            n.iter = 200,
+            seed = 47
+        )
+
+        res2 <- run_mcmc_p(
+            dt = sample_time,
+            set_prior(pred = "all", prior = "gamma", r0 = 1,  alpha = c(0, 0)),
+            n.chains = 2,
+            n.adapt = 100,
+            n.burn = 100,
+            n.iter = 200,
+            seed = 47,
+            n.cores = 2
+        )
+    })
+
+    expect_equal(res, res2)
+})
+
+


### PR DESCRIPTION
Closes #10 

As per the commit message I

- Added ncores argument so users can use more than 2 cores (but default to 2 to appease CRAN)
- Refactored some of the code to reduce lintr warnings (i.e. changing `=` to `<-`)
- Converted one of the print statements to use message as it was actually using cat instead