### PR TITLE
Add quiet option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,8 @@ Suggests:
     Matrix,
     assertthat
 VignetteBuilder: knitr
-Collate: 
+Collate:
+    'zzz.R'
     'add_cov.R'
     'add_time.R'
     'add_mcmc.R'

--- a/R/add_cov.R
+++ b/R/add_cov.R
@@ -24,13 +24,13 @@ setClassUnion("matrixORNULL", c("matrix", "NULL"))
 #' @keywords constructor
 set_n <- function(ssC, ssE, ssExt){
   if (missing(ssC) || !is.numeric(ssC)) {
-    message("ssC is not correctly specified. Default value 100 is used"); ssC = 100
+    ps_message("ssC is not correctly specified. Default value 100 is used"); ssC = 100
   }
   if (missing(ssE) || !is.numeric(ssE)) {
-    message("ssE is not recognized. ssC is used"); ssE = ssC
+    ps_message("ssE is not recognized. ssC is used"); ssE = ssC
   }
   if (missing(ssExt) || !is.numeric(ssExt)) {
-    message("ssExt is not recognized. ssC is used"); ssExt = ssC
+    ps_message("ssExt is not recognized. ssC is used"); ssExt = ssC
   }
   s_trt(ssC, ssE, ssExt) # call function from utils.R
 }
@@ -88,26 +88,26 @@ set_cov <- function(n_cat, n_cont, mu_int, mu_ext, var, cov, prob_int, prob_ext)
   # print(paste("total number of covariates", n_cov))
 
   if (missing(mu_int) || length(mu_int) %notin% c(1,n_cov)){
-    message("Mean of covariate in internal trials is not recognized or correctly specified. Default value 0 is used for all covariates")
+    ps_message("Mean of covariate in internal trials is not recognized or correctly specified. Default value 0 is used for all covariates")
     mu_int = rep(0, n_cov)
   } else if (n_cov != 1 & length(mu_int) == 1){
-    message("User provides one mean of covariate in internal trials. This value is used for all covariates")
+    ps_message("User provides one mean of covariate in internal trials. This value is used for all covariates")
     mu_int = rep(mu_int, n_cov)
   }
 
   if (missing(mu_ext) || length(mu_ext) %notin% c(1,n_cov)){
-    message("Mean of covariate in external trials is not recognized or correctly specified. mu_int is used for all covariates")
+    ps_message("Mean of covariate in external trials is not recognized or correctly specified. mu_int is used for all covariates")
     mu_ext = mu_int
   } else if (n_cov != 1 & length(mu_ext) == 1){
-    message("User provides one mean of covariate in external trials. This value is used for all covariates")
+    ps_message("User provides one mean of covariate in external trials. This value is used for all covariates")
     mu_ext = rep(mu_ext, n_cov)
   }
 
   if (missing(var) || length(var) %notin% c(1,n_cov)){
-    message("Variance of covariate in external trials is not recognized or correctly specified. Default value 1 is used for all covariates")
+    ps_message("Variance of covariate in external trials is not recognized or correctly specified. Default value 1 is used for all covariates")
     var = rep(1, n_cov)
   } else if (n_cov != 1 & length(var) == 1){
-    message("User provides one number for variance. This variance is used for all covariates")
+    ps_message("User provides one number for variance. This variance is used for all covariates")
     var = rep(var, n_cov)
   }
 
@@ -115,10 +115,10 @@ set_cov <- function(n_cat, n_cont, mu_int, mu_ext, var, cov, prob_int, prob_ext)
   if (n_cov > 1){
     len_cov = sum(seq(1, n_cov - 1, by = 1))
     if (length(cov) %notin% c(1, len_cov)) {
-      message("Covariance for covariate (cov) is not recognized. Default value 0 is used for all covariates")
+      ps_message("Covariance for covariate (cov) is not recognized. Default value 0 is used for all covariates")
       cov = rep(0, len_cov)
     } else if (length(cov) == 1){
-      message("User provides one number: ", cov, " for covariance. This covariance is used for all covariates")
+      ps_message("User provides one number: ", cov, " for covariance. This covariance is used for all covariates")
       cov = rep(cov, len_cov)
     }
   }
@@ -127,18 +127,18 @@ set_cov <- function(n_cat, n_cont, mu_int, mu_ext, var, cov, prob_int, prob_ext)
   if (missing(prob_ext)) prob_ext = NULL
   if (n_cat > 0){
     if (length(prob_int) %notin% c(1,n_cat)){
-      message("Probability of binary covariate in the internal trial is not recognized or correctly specified. Default value 0.5 is used for all binary covariates")
+      ps_message("Probability of binary covariate in the internal trial is not recognized or correctly specified. Default value 0.5 is used for all binary covariates")
       prob_int = rep(0.5, n_cat)
     } else if (length(prob_int) == 1){
-      message("User provides one number for probability for the binary covariate in the internal trial. This probability is used for all binary covariates")
+      ps_message("User provides one number for probability for the binary covariate in the internal trial. This probability is used for all binary covariates")
       prob_int = rep(prob_int, n_cat)
     }
 
     if (length(prob_ext) %notin% c(1,n_cat)){
-      message("Probability of binary covariate in the external trial is not recognized or correctly specified. mu_int is used.")
+      ps_message("Probability of binary covariate in the external trial is not recognized or correctly specified. mu_int is used.")
       prob_ext = prob_int
     } else if (length(prob_ext) == 1){
-      message("User provides one number for probability for the binary covariate in the external trial. This probability is used for all binary covariates")
+      ps_message("User provides one number for probability for the binary covariate in the external trial. This probability is used for all binary covariates")
       prob_ext = rep(prob_ext, n_cat)
     }
   }
@@ -192,7 +192,7 @@ setMethod("c", signature(x = ".covClass"), function(x, ...){
 add_cov=function(dt, covObj, seed){
 
   if (missing(seed)){
-    message("Setting up covariance... Set seed to ",.Random.seed[1])
+    ps_message("Setting up covariance... Set seed to ",.Random.seed[1])
     seed = .Random.seed[1]
   } else set.seed(seed)
 

--- a/R/add_mcmc.R
+++ b/R/add_mcmc.R
@@ -42,24 +42,24 @@ setClassUnion("matrixORNULL", c("matrix", "NULL"))
 set_prior <- function(pred, prior, r0, alpha, sigma) {
   # if (missing(pred)) {
   #   pred = "none"
-  #   message("Predictors to include in the weibull distribution (pred) is not provided. No predictor is used.")
+  #   ps_message("Predictors to include in the weibull distribution (pred) is not provided. No predictor is used.")
   #
   # }  else if (sum(grepl("none", pred)) > 0) {
   #   pred = "none"
-  #   message("Input none is found in pred. Any other input is disregarded.")
+  #   ps_message("Input none is found in pred. Any other input is disregarded.")
   # } else if (sum(grepl("all", pred)) > 0) {
   #   pred = "all"
-  #   message("Input all is found in pred. Any other input is disregarded.")
+  #   ps_message("Input all is found in pred. Any other input is disregarded.")
   # } else if (sum(grepl("ps", pred)) == 0) {
-  #   message(cat("Selected covariate(s)", pred, "are used as predictors in the weibull distribution. Any other input is disregarded. \n"))
+  #   ps_message(cat("Selected covariate(s)", pred, "are used as predictors in the weibull distribution. Any other input is disregarded. \n"))
   # } else if (sum(grepl("ps", pred)) > 0 & ("wgt" %in% colnames(dt))) { # column wgt already existed
-  #   message("Weight already provided in the data. It is used as predictor directly. \n")
+  #   ps_message("Weight already provided in the data. It is used as predictor directly. \n")
   #
   # } else if (sum(grepl("ps", pred)) > 0 & length(pred) == 1){ # column wgt does not exist
   #   # dt_ps <- c_ps(dt, cov_name)
-  #   message(cat("Propensity score calculated based on all covariates is used as predictors in the weibull distribution.\n"))
+  #   ps_message(cat("Propensity score calculated based on all covariates is used as predictors in the weibull distribution.\n"))
   # } else if (sum(grepl("ps", pred)) > 0 & length(pred) > 1){
-  #   message(cat("Propensity score calculated based selected covariate(s)", pred[pred != "ps"],
+  #   ps_message(cat("Propensity score calculated based selected covariate(s)", pred[pred != "ps"],
   #               "is used as predictors in the weibull distribution.\n"))
   # }
 
@@ -71,21 +71,21 @@ set_prior <- function(pred, prior, r0, alpha, sigma) {
 
   if(missing(r0)) {
     r0 = 1
-    message('No initial values for the shape of the weibull distribution (r0) is detected. Default value 1 is used')
+    ps_message('No initial values for the shape of the weibull distribution (r0) is detected. Default value 1 is used')
   }
 
   if(missing(alpha) || (prior %in% c("gamma", "cauchy", "unif") & length(alpha) != 2)) {
     alpha = c(0, 0)
-    message('Values for log of baseline hazard rate for external and internal control arms (alpha) is not correctly specified. Default value 0 is used.')
+    ps_message('Values for log of baseline hazard rate for external and internal control arms (alpha) is not correctly specified. Default value 0 is used.')
   }
   if (missing(alpha) || (prior %in% c("no_ext", "full_ext") & length(alpha) != 1)){
     alpha = 0
-    message('Values for log of baseline hazard rate for external and internal control arms (alpha) is not correctly specified. Default value 0 is used.')
+    ps_message('Values for log of baseline hazard rate for external and internal control arms (alpha) is not correctly specified. Default value 0 is used.')
   }
   if (missing(sigma)) sigma = NULL
   if (prior %in% c("cauchy", "unif") & length(sigma) != 1) {
     sigma = 0.03
-    message("Initial value for precision parameter (sigma) is missing or not correctly specified. Default value 0.03 is used.")
+    ps_message("Initial value for precision parameter (sigma) is missing or not correctly specified. Default value 0.03 is used.")
   }
   new(".priorClass", pred = pred, prior = prior, r0 = r0, alpha = alpha, sigma = sigma)
 }
@@ -140,7 +140,7 @@ add_mcmc = function(dt, priorObj, n.chains, n.adapt, n.burn,  n.iter, seed){
   flog.debug(cat("[add_mcmc] cov_name =", cov_name, "\n"))
 
   if (missing(seed)){
-    message("Setting up MCMC... Set seed to ",.Random.seed[1])
+    ps_message("Setting up MCMC... Set seed to ",.Random.seed[1])
     seed = .Random.seed[1]
   } else set.seed(seed)
 
@@ -155,24 +155,24 @@ add_mcmc = function(dt, priorObj, n.chains, n.adapt, n.burn,  n.iter, seed){
     #---
     if (missing(pred)) {
       pred = "none"
-      message("Predictors to include in the weibull distribution (pred) is not provided. No predictor is used.")
+      ps_message("Predictors to include in the weibull distribution (pred) is not provided. No predictor is used.")
     } else if (sum(pred %notin% c(cov_name, "none", "ps", "all")) > 0 ){
       stop("pred is not correctly specified. Options include none, ps, all and covariate names start with cov.")
     } else if (sum(grepl("none", pred)) > 0) {
       pred = "none"
-      message("Input none is found in pred. Any other input is disregarded.")
+      ps_message("Input none is found in pred. Any other input is disregarded.")
     } else if (sum(grepl("all", pred)) > 0) {
       pred = "all"
-      message("Input all is found in pred. Any other input is disregarded.")
+      ps_message("Input all is found in pred. Any other input is disregarded.")
     } else if (sum(grepl("ps", pred)) == 0) {
-      message(cat("Selected covariate(s)", pred, "are used as predictors in the weibull distribution.\n"))
+      ps_message(cat("Selected covariate(s)", pred, "are used as predictors in the weibull distribution.\n"))
     } else if (sum(grepl("ps", pred)) > 0 & length(pred) == 1){ # column wgt does not exist
       dt_ps <- c_ps(dt, cov_name)
-      message(cat("Propensity score calculated using all coariates", cov_name, "is used as predictors in the weibull distribution.\n"))
+      ps_message(cat("Propensity score calculated using all coariates", cov_name, "is used as predictors in the weibull distribution.\n"))
     } else if (sum(grepl("ps", pred)) > 0 & ("wgt" %in% colnames(dt))) { # column wgt already existed
-      message("Weight already provided in the data. It is used as predictor directly. \n")
+      ps_message("Weight already provided in the data. It is used as predictor directly. \n")
     } else if (sum(grepl("ps", pred)) > 0 & length(pred) > 1){
-      message(cat("Propensity score calculated based selected covariate(s)", pred[pred != "ps"],
+      ps_message(cat("Propensity score calculated based selected covariate(s)", pred[pred != "ps"],
                   "is used as predictors in the weibull distribution.\n"))
     }
 
@@ -207,19 +207,19 @@ add_mcmc = function(dt, priorObj, n.chains, n.adapt, n.burn,  n.iter, seed){
 valid_mcmc <- function(n.chains, n.adapt, n.burn,  n.iter){
   if (missing(n.chains) || !is.numeric(n.chains)) {
     n.chains = 2
-    message("No number of parallel chains for the model is provided. Default value 2 is used")
+    ps_message("No number of parallel chains for the model is provided. Default value 2 is used")
   }
   if (missing(n.adapt) || !is.numeric(n.chains)) {
     n.adapt = 1000
-    message("No Number of iterations for adaptation (n.adapt) is provided. Default value 1000 is used")
+    ps_message("No Number of iterations for adaptation (n.adapt) is provided. Default value 1000 is used")
   }
   if (missing(n.burn) || !is.numeric(n.burn)) {
     n.burn = 0
-    message("No mumber of iterations discarded as burn-in (n.burn) is provided. No iteration will be discarded.")
+    ps_message("No mumber of iterations discarded as burn-in (n.burn) is provided. No iteration will be discarded.")
   }
   if (missing(n.iter) || !is.numeric(n.iter)) {
     n.iter = 10000
-    message("No number of iterations to monitor is provided. Default value 10000 is used")
+    ps_message("No number of iterations to monitor is provided. Default value 10000 is used")
   }
   return(list("n.chains" = n.chains, "n.adapt" = n.adapt, "n.burn" = n.burn, "n.iter" = n.iter))
 }

--- a/R/add_time.R
+++ b/R/add_time.R
@@ -57,7 +57,7 @@ set_clin <- function(gamma, e_itv, CCOD, CCOD_t, etaC, etaE, d_itv) {
 
   if (missing(etaC)) stop("Please specify dropout rate per unit time for control arm (etaC).")
   if (missing(etaE) || length(etaC) != length(etaE)) {
-    message("Dropout rate per unit time for treatment arm (etaE) is not specified correcly. Disregard this warning if this is for external trial. Otherwise the same dropout rate as eta is used.")
+    ps_message("Dropout rate per unit time for treatment arm (etaE) is not specified correcly. Disregard this warning if this is for external trial. Otherwise the same dropout rate as eta is used.")
     etaE = etaC
   }
   if(missing(d_itv)) d_itv = NULL
@@ -133,7 +133,7 @@ add_time=function(dt, eventObj, clinInt, clinExt, seed){
   if (missing(clinInt)) stop("Please provide clinInt.")
   if (missing(clinExt)) stop("Please provide clinExt.")
   if (missing(seed)){
-    message("Setting up survival time... Set seed to ",.Random.seed[1])
+    ps_message("Setting up survival time... Set seed to ",.Random.seed[1])
     seed = .Random.seed[1]
   } else set.seed(seed)
 
@@ -147,10 +147,10 @@ add_time=function(dt, eventObj, clinInt, clinExt, seed){
   keep = eventObj@keep
   if (is.null(keep)) {
     keep = cov_name
-    message(cat("All original covariates (if any):", keep, "are used for time-to-failure."))
+    ps_message(cat("All original covariates (if any):", keep, "are used for time-to-failure."))
   } else if (sum(grepl("none", keep)) > 0){
     keep = NULL
-    message("No original covariates are used for time-to-failure.")
+    ps_message("No original covariates are used for time-to-failure.")
   } else if (sum(keep %notin% cov_name) > 0) {
     stop("Please correctly specify the covariates to keep when simulating failure times.")
   }
@@ -186,10 +186,10 @@ add_time=function(dt, eventObj, clinInt, clinExt, seed){
 
   beta = eventObj@beta
   if (length(beta) %notin% c(1, n_cov)){
-    message("Coefficient for covariates (beta) is not recognized or correctly specified. Default value 1 is used for all covariates")
+    ps_message("Coefficient for covariates (beta) is not recognized or correctly specified. Default value 1 is used for all covariates")
     beta = rep(1, n_cov)
   } else if (length(beta) == 1){
-    message("User provides one coefficient for covariate. This value is used for all covariates")
+    ps_message("User provides one coefficient for covariate. This value is used for all covariates")
     beta = rep(beta, n_cov)
   }
 

--- a/R/run_mcmc.R
+++ b/R/run_mcmc.R
@@ -27,7 +27,7 @@ run_mcmc <- function(dt, priorObj, n.chains, n.adapt, n.burn, n.iter, seed, path
   n_mcmc <- valid_mcmc(n.chains, n.adapt, n.burn, n.iter)
   
   if (missing(seed)){
-    message("Setting up Bayes model... Set seed to ",.Random.seed[1])
+    ps_message("Setting up Bayes model... Set seed to ",.Random.seed[1])
     seed = .Random.seed[1]
   } else set.seed(seed)
   seed_list <- seq(seed, seed + length(dt), by = 1)
@@ -37,7 +37,7 @@ run_mcmc <- function(dt, priorObj, n.chains, n.adapt, n.burn, n.iter, seed, path
   res_list <- sapply(seq(1, length(dt), by = 1), function(i){
     seed_i = seed_list[i]
     
-    message("------------------- Running MCMC: #", i, " of ", length(dt), " simulated dataset with seed = ", seed_i)
+    ps_message("------------------- Running MCMC: #", i, " of ", length(dt), " simulated dataset with seed = ", seed_i)
     
     add_mcmc(dt = dt[[i]], priorObj = priorObj,
              n.chains = n.chains, n.adapt = n.adapt,
@@ -62,9 +62,9 @@ run_mcmc <- function(dt, priorObj, n.chains, n.adapt, n.burn, n.iter, seed, path
   sum_dt$mean_driftHR = as.numeric(sum_dt$mean_driftHR)
   sum_dt$sd_driftHR = as.numeric(sum_dt$sd_driftHR)
   
-  if (missing(path)) message("Samples from the posterior distribution from MCMC are not saved.") else {
+  if (missing(path)) ps_message("Samples from the posterior distribution from MCMC are not saved.") else {
     save(sum_dt, file = path)
-    message("Results the posterior distribution from MCMC are saved as ", path)
+    ps_message("Results the posterior distribution from MCMC are saved as ", path)
   }
   
   sum_dt
@@ -97,7 +97,7 @@ run_mcmc_p <- function(dt, priorObj, n.chains, n.adapt, n.burn, n.iter, seed, pa
   n_mcmc <- valid_mcmc(n.chains, n.adapt, n.burn, n.iter)
   
   if (missing(seed)){
-    message("Running MCMC... Set seed to ", .Random.seed[1])
+    ps_message("Running MCMC... Set seed to ", .Random.seed[1])
     seed = .Random.seed[1]
   } else set.seed(seed)
   seed_list <- seq(seed, seed + length(dt), by = 1)
@@ -106,7 +106,7 @@ run_mcmc_p <- function(dt, priorObj, n.chains, n.adapt, n.burn, n.iter, seed, pa
   
   # nCluster <- parallel::detectCores()
   nCluster <- 2 # switch to 2 cluster per CRAN's requirement
-  message(nCluster, " clusters are being used")
+  ps_message(nCluster, " clusters are being used")
   cl <- parallel::makeCluster(nCluster)
   doParallel::registerDoParallel(cl)
   
@@ -120,7 +120,7 @@ run_mcmc_p <- function(dt, priorObj, n.chains, n.adapt, n.burn, n.iter, seed, pa
                         
                         seed_i = seed_list[i]
                         
-                        message("------------------- Running MCMC: #", i, " of ", length(dt), " simulated dataset with seed = ", seed_i)
+                        ps_message("------------------- Running MCMC: #", i, " of ", length(dt), " simulated dataset with seed = ", seed_i)
                         
                         add_mcmc(dt = dt[[i]], priorObj = priorObj,
                                  n.chains = n.chains, n.adapt = n.adapt,
@@ -146,9 +146,9 @@ run_mcmc_p <- function(dt, priorObj, n.chains, n.adapt, n.burn, n.iter, seed, pa
   sum_dt$mean_driftHR = as.numeric(sum_dt$mean_driftHR)
   sum_dt$sd_driftHR = as.numeric(sum_dt$sd_driftHR)
   
-  if (missing(path)) message("Samples from the posterior distribution from MCMC are not saved.") else {
+  if (missing(path)) ps_message("Samples from the posterior distribution from MCMC are not saved.") else {
     save(sum_dt, file = path)
-    message("Results the posterior distribution from MCMC are saved as ", path)
+    ps_message("Results the posterior distribution from MCMC are saved as ", path)
   }
   sum_dt
 }

--- a/R/simu_cov.R
+++ b/R/simu_cov.R
@@ -37,19 +37,19 @@ simu_cov=function(ssObj, covObj, driftHR, HR, nsim, seed, path){
 
   if (missing(ssObj)) stop("Please provide ssObj.")
   if (missing(covObj)) {
-    message("No covObj is provided.")
+    ps_message("No covObj is provided.")
     covObj = NULL
   }
   if (missing(HR)){
     HR = 1
-    message("HR values (HR) not provided. Default value 1 is used.")
+    ps_message("HR values (HR) not provided. Default value 1 is used.")
   }
   if (missing(driftHR)){
     driftHR = 1
-    message("driftHR values (driftHR) not provided. Default value 1 is used.")
+    ps_message("driftHR values (driftHR) not provided. Default value 1 is used.")
   }
   if (missing(nsim)) {
-    message("Number of simulation is not provided. Default value 5 is used")
+    ps_message("Number of simulation is not provided. Default value 5 is used")
     nsim = 5
   }
 
@@ -59,11 +59,11 @@ simu_cov=function(ssObj, covObj, driftHR, HR, nsim, seed, path){
   ssE <- sum(dt0[,'ext'] ==0 & dt0[,'trt'] ==1)
   ssExt <- sum(dt0[,'ext'] ==1)
 
-  message(paste0("The sample size for internal control, internal treatment, and external control arms are ",
+  ps_message(paste0("The sample size for internal control, internal treatment, and external control arms are ",
                  ssC, ", ", ssE, ", and ", ssExt,", respectively."))
 
   if (missing(seed)){
-    message(paste0("Set seed to ",.Random.seed[1]))
+    ps_message(paste0("Set seed to ",.Random.seed[1]))
     seed = .Random.seed[1]
   } else set.seed(seed)
 
@@ -80,7 +80,7 @@ simu_cov=function(ssObj, covObj, driftHR, HR, nsim, seed, path){
       nsim_res <-  lapply(seq(1, nsim, by = 1), function(i){
         seed_i = seed_list[i, j, k]
 
-        message("------------------- #", i, "of ", nsim, "simulation: #",
+        ps_message("------------------- #", i, "of ", nsim, "simulation: #",
                     j, "of HR =", hr, ", #",
                     k, "of driftHR = ", dr, ", seed =", seed_i)
 
@@ -98,9 +98,9 @@ simu_cov=function(ssObj, covObj, driftHR, HR, nsim, seed, path){
   })
 
 
-  if (missing(path)) message("Simulated covariates are not saved.") else {
+  if (missing(path)) ps_message("Simulated covariates are not saved.") else {
     save(res_list, file = path)
-    message("Simulated covariates are saved as ", path)
+    ps_message("Simulated covariates are saved as ", path)
   }
   res_list
 }

--- a/R/simu_time.R
+++ b/R/simu_time.R
@@ -39,7 +39,7 @@ simu_time = function(dt, eventObj, clinInt, clinExt, seed, path){
   if (missing(clinInt)) stop("Please provide clinInt.")
   if (missing(clinExt)) stop("Please provide clinExt.")
   if (missing(seed)){
-    message("Simulating survival time... Set seed to ",.Random.seed[1])
+    ps_message("Simulating survival time... Set seed to ",.Random.seed[1])
     seed = .Random.seed[1]
   } else set.seed(seed)
 
@@ -51,9 +51,9 @@ simu_time = function(dt, eventObj, clinInt, clinExt, seed, path){
     add_time(dt = dt[[i]], eventObj = eventObj, clinInt = clinInt, clinExt = clinExt, seed = seed_i)
   }) #loop foreach
 
-  if (missing(path)) message("Simulated time are not saved.") else {
+  if (missing(path)) ps_message("Simulated time are not saved.") else {
     save(res_list, file = path)
-    message("Simulated time are saved as", path)
+    ps_message("Simulated time are saved as", path)
   }
   res_list
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,5 @@
+
+.onLoad = function(libname, pkgname) {
+    options("psborrow.quiet" = FALSE)
+    invisible()
+}

--- a/tests/testthat/test-quiet.R
+++ b/tests/testthat/test-quiet.R
@@ -1,0 +1,103 @@
+library(dplyr)
+
+get_sim_data <- function() {
+    set.seed(3015)
+
+    ss <- set_n(
+        ssC = 70,
+        ssE = 90,
+        ssExt = 130
+    )
+
+    covset1 <- set_cov(
+        n_cat = 1,
+        n_cont = 1,
+        mu_int = c(0, 0.5),
+        mu_ext = c(0.7, 0.5),
+        var = c(1, 1.2, 1),
+        cov = c(0.5, 0.7),
+        prob_int = c(0.45),
+        prob_ext = c(0.65)
+    )
+
+    sample_cov <- simu_cov(
+        ssObj = ss,
+        covObj = covset1,
+        HR = c(0.67),
+        driftHR = c(1),
+        nsim = 1,
+        seed = 47
+    )
+
+    evt <- set_event(
+        event = "weibull",
+        shape = 0.9,
+        lambdaC = 0.0135,
+        beta = 0.5
+    )
+
+    c_int <- set_clin(
+        gamma = c(2, 3, 16),
+        e_itv = c(5, 10),
+        CCOD = "fixed-first",
+        CCOD_t = 45,
+        etaC = c(0.02, 0.03),
+        etaE = c(0.2, 0.3),
+        d_itv = 2
+    )
+
+
+    c_ext <- set_clin(
+        gamma = 10,
+        CCOD = "event",
+        CCOD_t = 150,
+        etaC = 0.05
+    )
+
+
+    sample_time <- simu_time(
+        dt = sample_cov,
+        eventObj = evt,
+        clinInt = c_int,
+        clinExt = c_ext,
+        seed = 47
+    )
+
+    res <- run_mcmc(
+        dt = sample_time,
+        set_prior(pred = "all", prior = "gamma", r0 = 1,  alpha = c(0, 0)),
+        n.chains = 2,
+        n.adapt = 100,
+        n.burn = 100,
+        n.iter = 200,
+        seed = 47
+    )
+
+    summ <- get_summary(res)
+    return(summ)
+}
+
+
+
+test_that("Using quiet supresses messages as expected", {
+
+    options("psborrow.quiet" = TRUE)
+    quiet_output <- capture_output({
+        quiet_msg <- capture_messages({
+            quiet_result <- get_sim_data()
+        })
+    })
+
+    options("psborrow.quiet" = FALSE)
+    loud_output <- capture_output({
+        loud_msg <- capture_messages({
+            loud_result <- get_sim_data()
+        })
+    })
+
+    expect_true(quiet_output == "")
+    expect_true(length(quiet_msg) == 0)
+    expect_true(loud_output != "")
+    expect_true(length(loud_msg) > 0)
+    expect_equal(quiet_result, loud_result)
+})

--- a/vignettes/user_guide.Rmd
+++ b/vignettes/user_guide.Rmd
@@ -34,6 +34,7 @@ Here we demonstrate the usage of the package with an example. The goal is to:
 library(psborrow)
 ```
 
+
 ## Simulate covariates
 
 We start with making the sample size for internal control, internal treatment, and external control arms to be 200, 180 and 400 respectively.
@@ -297,3 +298,13 @@ plot_hr(summ, HR = 0.67, driftHR = 1.2, pred = "all")
 plot_bias(summ, HR = 1, driftHR = 1.2, pred = "all")
 plot_mse(summ, HR = 0.67, driftHR = 1, pred = "all")
 ```
+
+## Package Options
+
+By default `psborrow` is quite chatty informing the user explicitly about what assumptions it is making.
+If you want to suppress these messages simply specify:
+
+```
+options("psborrow.quiet" = TRUE)
+```
+


### PR DESCRIPTION
Closes #20 

- Added global option `"psborrow.quiet"` which if set to `TRUE` stops all message printing 
- Added new wrapper function `ps_message()`  around the `message()` function which only prints the message if `psborrow.quiet` is `FALSE`
- Converted all `message()` functions to use `ps_message()`
- Added unit test to show this is working as expected
- Added basic documentation to the vignette

This highlighted to me that there are a few cases of a `message()` calls containing a `cat()` command which ends up printing the message to the stdout instead of as a message, I think I fixed a few of these in ~#21~ #31  so once that and this is merged we should probs look at which ones after left over that still need to be cleaned up. 